### PR TITLE
Add New Relic Java agent docker example with SpringBoot PetClinic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea
 out/
 build
+.DS_Store

--- a/newrelic-java-agent/installation/new-relic-java-agent-docker/Dockerfile
+++ b/newrelic-java-agent/installation/new-relic-java-agent-docker/Dockerfile
@@ -1,0 +1,44 @@
+# BUILD STAGE
+FROM eclipse-temurin:17-jdk-jammy as build
+
+# Install git
+RUN apt update
+RUN apt install -y git
+
+# Clone and build SpringBoot PetClinic Java service
+RUN git clone https://github.com/spring-projects/spring-petclinic
+# Checkout a specific commit to pin the PetClinic service to a known working version. Comment this out to get latest version.
+RUN cd ./spring-petclinic && git checkout 923e2b7aa331b8194a6579da99fb6388f15d7f3e
+# Build SpringBoot PetClinic Java service
+RUN cd ./spring-petclinic && ./mvnw -Dmaven.test.skip=true clean package
+
+
+# PRODUCTION STAGE
+FROM eclipse-temurin:17-jre-jammy as production
+
+# Create work directory
+WORKDIR /petclinic-app
+
+# Copy PetClinic jar from build stage to work directory
+COPY --from=build /spring-petclinic/target/spring-petclinic*.jar .
+
+# Add New Relic Java agent jar to work directory
+RUN curl -O https://download.newrelic.com/newrelic/java-agent/newrelic-agent/8.7.0/newrelic-agent-8.7.0.jar
+
+# SpringBoot listens on port 8080 by default
+# To change it set the -Dserver.port=8083 system propery in the following CMD step
+# Alternatively, change the SERVER_PORT and port mapping in docker-compose.yml
+EXPOSE 8080
+
+# Configure Java agent
+ENV NEW_RELIC_APP_NAME=JavaPetClinic
+ENV NEW_RELIC_LICENSE_KEY='<license_key>'
+ENV NEW_RELIC_JFR_ENABLED=true
+
+ENV NEW_RELIC_HOST=collector.newrelic.com
+ENV NEW_RELIC_API_HOST=rpm.newrelic.com
+ENV NEW_RELIC_METRIC_INGEST_URI=https://metric-api.newrelic.com/metric/v1
+ENV NEW_RELIC_EVENT_INGEST_URI=https://insights-collector.newrelic.com/v1/accounts/events
+
+# Run SpringBoot PetClinic Java service with the New Relic Java agent attached
+CMD java -javaagent:newrelic-agent-8.7.0.jar -jar spring-petclinic*.jar

--- a/newrelic-java-agent/installation/new-relic-java-agent-docker/README.md
+++ b/newrelic-java-agent/installation/new-relic-java-agent-docker/README.md
@@ -1,0 +1,68 @@
+# Dockerized Springboot Petclinic Service With New Relic Java Agent
+
+Dockerized version of the [SpringBoot PetClinic service](https://github.com/spring-projects/spring-petclinic) with the [New Relic Java Agent](https://docs.newrelic.com/docs/apm/agents/java-agent/getting-started/introduction-new-relic-java/).
+
+## Configure the Java agent
+
+Before running the container you must modify the following environment variables in the Dockerfile to configure where the Java agent reports.
+
+These two define a unique entity that is associated with a specific APM account and New Relic environment:
+* Set the APM entity name: `ENV NEW_RELIC_APP_NAME=JavaPetClinic`
+* License key for account: `ENV NEW_RELIC_LICENSE_KEY='<license_key>'`
+
+Set the following based on which New Relic environment the APM account is associated with:
+* US Production
+    ```
+    ENV NEW_RELIC_HOST=collector.newrelic.com
+    ENV NEW_RELIC_API_HOST=rpm.newrelic.com
+    ENV NEW_RELIC_METRIC_INGEST_URI=https://metric-api.newrelic.com/metric/v1
+    ENV NEW_RELIC_EVENT_INGEST_URI=https://insights-collector.newrelic.com/v1/accounts/events
+    ```
+* EU Production
+    ```
+    ENV NEW_RELIC_HOST=collector.eu01.nr-data.net
+    ENV NEW_RELIC_API_HOST=api.eu.newrelic.com
+    ENV NEW_RELIC_METRIC_INGEST_URI=https://metric-api.eu.newrelic.com/metric/v1
+    ENV NEW_RELIC_EVENT_INGEST_URI=https://insights-collector.eu01.nr-data.net/v1/accounts/events
+    ```
+* US Staging
+    ```
+    ENV NEW_RELIC_HOST=staging-collector.newrelic.com
+    ENV NEW_RELIC_API_HOST=staging.newrelic.com
+    ENV NEW_RELIC_METRIC_INGEST_URI=https://staging-metric-api.newrelic.com/metric/v1
+    ENV NEW_RELIC_EVENT_INGEST_URI=https://staging-insights-collector.newrelic.com/v1/accounts/events
+    ```
+
+(OPTIONAL) Enable JFR monitoring for enhanced JVM details:
+* `ENV NEW_RELIC_JFR_ENABLED=true`
+
+See [Java agent configuration](https://docs.newrelic.com/docs/apm/agents/java-agent/configuration/java-agent-configuration-config-file/) for a complete list of config options.
+
+## Building/Running Dockerized Petclinic Service
+
+### Option 1: Docker Compose
+
+Build and run:
+`docker-compose up -d`
+
+Stop:
+`docker-compose down`
+
+### Option 2: Docker Build/Run
+
+Build Docker Image:
+`docker build --tag petclinic-app .`
+
+Run Docker Container:
+`docker run -p 8080:8080 petclinic-app`
+
+Stop Docker Container:
+`docker ps`
+`docker stop <CONTAINER ID>`
+
+## Make a Request to the Petclinic Service
+
+By default, the Petclinic Service will be accessible at: http://localhost:8080
+
+Example `curl` request:  
+`curl --request GET --url http://localhost:8080/vets --header 'content-type: application/json'`

--- a/newrelic-java-agent/installation/new-relic-java-agent-docker/docker-compose.yml
+++ b/newrelic-java-agent/installation/new-relic-java-agent-docker/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  petclinic:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: production
+    ports:
+      - 8080:8080
+    environment:
+      - SERVER_PORT=8080


### PR DESCRIPTION
Adds an example of a dockerized version of the [SpringBoot PetClinic service](https://github.com/spring-projects/spring-petclinic) with the [New Relic Java Agent](https://docs.newrelic.com/docs/apm/agents/java-agent/getting-started/introduction-new-relic-java/). 