### PR TITLE
Update repolinter.yml

### DIFF
--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -13,6 +13,7 @@ jobs:
     name: Run Repolinter
     runs-on: ubuntu-latest
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow
       - name: Test Default Branch
         id: default-branch
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # pin@v7


### PR DESCRIPTION
Adds the permissions monitor action which tracks the usage of the temporary GitHub repository token and gives recommendations on the minimum permissions required to run the workflow based on the actual detected workflow activity.

Can be disabled once permissions have been determined and explicitly configured in the workflow.